### PR TITLE
Fixed Record Deployment

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
   "license": "proprietary",
   "require": {
     "php": ">=7.1",
+    "spryker/monitoring": "^2.0.0",
     "spryker/monitoring-extension": "^1.0.0",
     "spryker/kernel": "^3.0.0",
     "psr/http-message": "^1.0.0",
@@ -12,6 +13,10 @@
   "require-dev": {
     "codeception/codeception": "^2.0.0",
     "phpstan/phpstan": "^0.9.2 || ^0.10.0"
+  },
+  "conflict":  {
+    "spryker/new-relic": "*",
+    "spryker/new-relic-api": "*"
   },
   "autoload": {
     "psr-4": {

--- a/src/SprykerEco/Service/NewRelic/Plugin/NewRelicMonitoringExtensionPlugin.php
+++ b/src/SprykerEco/Service/NewRelic/Plugin/NewRelicMonitoringExtensionPlugin.php
@@ -56,7 +56,7 @@ class NewRelicMonitoringExtensionPlugin implements MonitoringExtensionPluginInte
 
         $this->application = $application . '-' . $store . ' (' . $environment . ')';
 
-        \newrelic_set_appname($this->application);
+        \newrelic_set_appname($this->application, null, false);
     }
 
     /**
@@ -106,6 +106,7 @@ class NewRelicMonitoringExtensionPlugin implements MonitoringExtensionPluginInte
             return;
         }
 
+        \newrelic_ignore_apdex();
         \newrelic_ignore_transaction();
     }
 

--- a/src/SprykerEco/Shared/NewRelic/NewRelicEnv.php
+++ b/src/SprykerEco/Shared/NewRelic/NewRelicEnv.php
@@ -28,7 +28,7 @@ interface NewRelicEnv
 
     /**
      * Specification:
-     * - NewRelic Application ID array
+     * - NewRelic Application ID array.
      *
      * @api
      */

--- a/src/SprykerEco/Shared/NewRelic/NewRelicEnv.php
+++ b/src/SprykerEco/Shared/NewRelic/NewRelicEnv.php
@@ -24,4 +24,13 @@ interface NewRelicEnv
      * @api
      */
     const NEW_RELIC_API_KEY = 'NEWRELIC:NEW_RELIC_API_KEY';
+
+
+    /**
+     * Specification:
+     * - NewRelic Application ID array
+     *
+     * @api
+     */
+    const NEW_RELIC_APPLICATION_ID_ARRAY = 'NEWRELIC:NEW_RELIC_APPLICATION_ID_ARRAY';
 }

--- a/src/SprykerEco/Zed/NewRelic/Business/NewRelicBusinessFactory.php
+++ b/src/SprykerEco/Zed/NewRelic/Business/NewRelicBusinessFactory.php
@@ -23,7 +23,8 @@ class NewRelicBusinessFactory extends AbstractBusinessFactory
     {
         return new RecordDeployment(
             $this->getConfig()->getNewRelicDeploymentApiUrl(),
-            $this->getConfig()->getNewRelicApiKey()
+            $this->getConfig()->getNewRelicApiKey(),
+            $this->getConfig()->getNewRelicApplicationIdArray()
         );
     }
 }

--- a/src/SprykerEco/Zed/NewRelic/Business/NewRelicFacade.php
+++ b/src/SprykerEco/Zed/NewRelic/Business/NewRelicFacade.php
@@ -22,6 +22,8 @@ class NewRelicFacade extends AbstractFacade implements NewRelicFacadeInterface
      *
      * @param array $arguments
      *
+     * @throws \SprykerEco\Zed\NewRelic\Business\Exception\RecordDeploymentException
+     *
      * @return \SprykerEco\Zed\NewRelic\Business\Model\RecordDeploymentInterface
      */
     public function recordDeployment(array $arguments = []): RecordDeploymentInterface

--- a/src/SprykerEco/Zed/NewRelic/Business/NewRelicFacadeInterface.php
+++ b/src/SprykerEco/Zed/NewRelic/Business/NewRelicFacadeInterface.php
@@ -22,6 +22,8 @@ interface NewRelicFacadeInterface
      *
      * @param array $arguments
      *
+     * @throws \SprykerEco\Zed\NewRelic\Business\Exception\RecordDeploymentException
+     *
      * @return \SprykerEco\Zed\NewRelic\Business\Model\RecordDeploymentInterface
      */
     public function recordDeployment(array $arguments = []): RecordDeploymentInterface;

--- a/src/SprykerEco/Zed/NewRelic/Communication/Console/RecordDeploymentConsole.php
+++ b/src/SprykerEco/Zed/NewRelic/Communication/Console/RecordDeploymentConsole.php
@@ -53,13 +53,13 @@ class RecordDeploymentConsole extends Console
 
         $this->addArgument(
             self::ARGUMENT_USER,
-            InputArgument::OPTIONAL,
+            InputArgument::REQUIRED,
             self::ARGUMENT_USER_DESCRIPTION
         );
 
         $this->addArgument(
             self::ARGUMENT_REVISION,
-            InputArgument::OPTIONAL,
+            InputArgument::REQUIRED,
             self::ARGUMENT_REVISION_DESCRIPTION
         );
 

--- a/src/SprykerEco/Zed/NewRelic/NewRelicConfig.php
+++ b/src/SprykerEco/Zed/NewRelic/NewRelicConfig.php
@@ -27,4 +27,12 @@ class NewRelicConfig extends AbstractBundleConfig
     {
         return $this->get(NewRelicEnv::NEW_RELIC_API_KEY);
     }
+
+    /**
+     * @return array
+     */
+    public function getNewRelicApplicationIdArray(): array
+    {
+        return $this->get(NewRelicEnv::NEW_RELIC_APPLICATION_ID_ARRAY, []);
+    }
 }


### PR DESCRIPTION
- Developer(s): @fciacchi 

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   NewRelic  | major                 | RecordDeployment     |

#### Release Notes

Fixed bug in monitoring where console commands are not correctly sent to the monitoring service.

-----------------------------------------

#### Module NewRelic

##### Change log

Improvements

* Fixed correct console command logging in `spryker/monitoring` here: https://github.com/spryker/spryker/pull/5555 - potential release version `2.0.0`
* Added conflict constraint to previous core version of the new-relic module
* Fixed wrong GuzzleHttp namespace. Composer force version 6.x.x
* Fixed required arguments for the record deployment. Only `revision` (the 3rd) is required, therefore since the first argument was already required, made the first 3 arguments all required
* Fixed the way record deployment is set to NewRelic API: https://docs.newrelic.com/docs/apm/new-relic-apm/maintenance/record-deployments
* Improved the record deployment in a retro-compatible way. The record deployment URL can contain only one application-id (that is NewRelic term for an environment). Added application-id array, so that record deployment URL can have `sprintf` style placeholder and a list of IDs can be passed separately.